### PR TITLE
Some more cleanups.

### DIFF
--- a/src/jepsen/redis/client.clj
+++ b/src/jepsen/redis/client.clj
@@ -76,8 +76,8 @@
            (catch [:prefix :nocluster] e#
              (assoc ~op :type :fail, :error :nocluster))
 
-           (catch [:prefix :noleader] e#
-             (assoc ~op :type :fail, :error :noleader))
+           (catch [:prefix :clusterdown] e#
+             (assoc ~op :type :fail, :error :clusterdown))
 
            (catch [:prefix :notleader] e#
              (assoc ~op :type :fail, :error :notleader))

--- a/src/jepsen/redis/core.clj
+++ b/src/jepsen/redis/core.clj
@@ -98,7 +98,7 @@
                              (gen/stagger (/ (:rate opts)))
                              (gen/nemesis (:generator nemesis))
                              (gen/time-limit (:time-limit opts)))
-            :name       (str "redis " (:version opts)
+            :name       (str "redis " (:redis-version opts)
                              " (raft " (:raft-version opts) ") "
                              (when (:follower-proxy opts)
                                "proxy ")
@@ -139,7 +139,7 @@
     :default true]
 
    [nil "--raft-version VERSION" "What version of redis-raft should we test?"
-    :default "master"]
+    :default "407ed4e"]
 
    [nil "--raft-repo URL" "Where we clone redis-raft from?"
     :default "https://github.com/redislabs/redisraft"]
@@ -165,7 +165,7 @@
     :default false]
 
    [nil "--redis-version VERSION" "What version of Redis should we test?"
-    :default "unstable"]
+    :default "6.2.2"]
 
    [nil "--redis-repo URL" "Where we clone redis from?"
     :default "https://github.com/redis/redis"]

--- a/src/jepsen/redis/core.clj
+++ b/src/jepsen/redis/core.clj
@@ -139,7 +139,10 @@
     :default true]
 
    [nil "--raft-version VERSION" "What version of redis-raft should we test?"
-    :default "e0123a9"]
+    :default "master"]
+
+   [nil "--raft-repo URL" "Where we clone redis-raft from?"
+    :default "https://github.com/redislabs/redisraft"]
 
    ["-r" "--rate HZ" "Approximate number of requests per second per thread"
     :default 10
@@ -161,8 +164,11 @@
    [nil "--tcpdump" "Create tcpdump logs for debugging client-server interaction"
     :default false]
 
-   ["-v" "--version VERSION" "What version of Redis should we test?"
-    :default "6.0.3"]
+   [nil "--redis-version VERSION" "What version of Redis should we test?"
+    :default "unstable"]
+
+   [nil "--redis-repo URL" "Where we clone redis from?"
+    :default "https://github.com/redis/redis"]
 
    ["-w" "--workload NAME" "What workload should we run?"
     :parse-fn keyword

--- a/src/jepsen/redis/db.clj
+++ b/src/jepsen/redis/db.clj
@@ -105,7 +105,7 @@
 (defn build-redis!
   "Compiles redis, and returns the directory we built in."
   [test node]
-  (let [version (:version test)]
+  (let [version (:redis-version test)]
     (with-build-version node "redis" version
       (let [dir (checkout-repo! (:redis-repo test) "redis" (:redis-version test))]
         (info "Building redis" (:redis-version test))
@@ -328,8 +328,8 @@
         (throw e)))))
 
 (defn redis-raft
-  "Sets up a Redis-Raft based cluster. Tests should include a :version option,
-  which will be the git SHA or tag to build."
+  "Sets up a Redis-Raft based cluster. Tests should include :redis-version
+  and :raft-version options, which will be the git SHA or tag to build."
   []
   (let [tcpdump (db/tcpdump {:ports [6379]
                              ; HAAACK, this is hardcoded for my cluster control

--- a/src/jepsen/redis/db.clj
+++ b/src/jepsen/redis/db.clj
@@ -21,14 +21,6 @@
   "A remote directory for us to clone projects and compile them."
   "/tmp/jepsen/build")
 
-(def redis-raft-repo
-  "Where can we clone redis-raft from?"
-  "https://github.com/RedisLabs/redisraft")
-
-(def redis-repo
-  "Where can we clone redis from?"
-  "https://github.com/redis/redis")
-
 (def dir
   "The remote directory where we deploy redis to"
   "/opt/redis")
@@ -100,7 +92,7 @@
   [test node]
   (let [version (:raft-version test)]
     (with-build-version node "redis-raft" version
-      (let [dir (checkout-repo! redis-raft-repo "redis-raft" version)]
+      (let [dir (checkout-repo! (:raft-repo test) "redis-raft" version)]
         (info "Building redis-raft" (:raft-version test))
         (c/cd dir
           (c/exec :git :submodule :init)
@@ -115,8 +107,8 @@
   [test node]
   (let [version (:version test)]
     (with-build-version node "redis" version
-      (let [dir (checkout-repo! redis-repo "redis" (:version test))]
-        (info "Building redis" (:version test))
+      (let [dir (checkout-repo! (:redis-repo test) "redis" (:redis-version test))]
+        (info "Building redis" (:redis-version test))
         (c/cd dir
           (c/exec :make :distclean)
           (c/exec :make))


### PR DESCRIPTION
* Redis Cluster compatible errors codes (`-CLUSTERDOWN` instead of `-NOLEADER`).
* Configurable source repositories.