### PR TITLE
Increased JVM max memory to 4gb

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,6 @@
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [jepsen "0.1.18"]
                  [com.taoensso/carmine "2.19.1"]]
-  :jvm-opts ["-Djava.awt.headless=true"]
+  :jvm-opts ["-Xmx4g" "-Djava.awt.headless=true"]
   :repl-options {:init-ns jepsen.redis.core}
   :main jepsen.redis.core)


### PR DESCRIPTION
We see out of memory errors occasionally. I don't know the root cause or if it can be avoided some other way but looks like increasing max memory solves the problem. After the fix, for my branch, I didn't get any OOM errors.

```
2021-10-06 05:02:54,002{GMT}	WARN	[clojure-agent-send-off-pool-304] jepsen.checker: Error while checking history:
java.util.concurrent.ExecutionException: java.lang.OutOfMemoryError: Java heap space
	at java.util.concurrent.FutureTask.report(FutureTask.java:122) [na:1.8.0_302]
	at java.util.concurrent.FutureTask.get(FutureTask.java:192) [na:1.8.0_302]
	at clojure.core$deref_future.invokeStatic(core.clj:2300) ~[clojure-1.10.0.jar:na]
	at clojure.core$future_call$reify__8439.deref(core.clj:6974) ~[clojure-1.10.0.jar:na]
	at clojure.core$deref.invokeStatic(core.clj:2320) ~[clojure-1.10.0.jar:na]
	at clojure.core$deref.invoke(core.clj:2306) ~[clojure-1.10.0.jar:na]
	at clojure.core$map$fn__5851.invoke(core.clj:2753) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.sval(LazySeq.java:42) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.seq(LazySeq.java:51) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.seq(RT.java:531) ~[clojure-1.10.0.jar:na]
	at clojure.core$seq__5387.invokeStatic(core.clj:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$map$fn__5855.invoke(core.clj:2757) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.sval(LazySeq.java:42) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.seq(LazySeq.java:51) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.seq(RT.java:531) ~[clojure-1.10.0.jar:na]
	at clojure.core$seq__5387.invokeStatic(core.clj:137) ~[clojure-1.10.0.jar:na]
	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:24) ~[clojure-1.10.0.jar:na]
	at clojure.core.protocols$fn__8131.invokeStatic(protocols.clj:75) ~[clojure-1.10.0.jar:na]
	at clojure.core.protocols$fn__8131.invoke(protocols.clj:75) ~[clojure-1.10.0.jar:na]
	at clojure.core.protocols$fn__8073$G__8068__8086.invoke(protocols.clj:13) ~[clojure-1.10.0.jar:na]
	at clojure.core$reduce.invokeStatic(core.clj:6828) ~[clojure-1.10.0.jar:na]
	at clojure.core$into.invokeStatic(core.clj:6895) ~[clojure-1.10.0.jar:na]
	at clojure.core$into.invoke(core.clj:6887) ~[clojure-1.10.0.jar:na]
	at jepsen.redis.db$logged_crashes.invokeStatic(db.clj:623) ~[classes/:na]
	at jepsen.redis.db$logged_crashes.invoke(db.clj:619) ~[classes/:na]
	at jepsen.redis.core$crash_checker$reify__6867.check(core.clj:63) ~[classes/:na]
	at jepsen.checker$check_safe.invokeStatic(checker.clj:84) [jepsen-0.1.18.jar:na]
	at jepsen.checker$check_safe.invoke(checker.clj:77) [jepsen-0.1.18.jar:na]
	at jepsen.checker$compose$reify__5060$fn__5062.invoke(checker.clj:100) [jepsen-0.1.18.jar:na]
	at clojure.core$pmap$fn__8447$fn__8448.invoke(core.clj:7022) [clojure-1.10.0.jar:na]
	at clojure.core$binding_conveyor_fn$fn__5739.invoke(core.clj:2030) [clojure-1.10.0.jar:na]
	at clojure.lang.AFn.call(AFn.java:18) [clojure-1.10.0.jar:na]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_302]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_302]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_302]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_302]
Caused by: java.lang.OutOfMemoryError: Java heap space
	at sun.security.util.math.intpoly.IntegerPolynomial$MutableElement.fixed(IntegerPolynomial.java:611) ~[na:1.8.0_302]
	at sun.security.util.math.intpoly.IntegerPolynomial$MutableElement.fixed(IntegerPolynomial.java:602) ~[na:1.8.0_302]
	at sun.security.ec.point.ProjectivePoint.fixed(ProjectivePoint.java:55) ~[sunec.jar:1.8.0_302]
	at sun.security.ec.ECOperations.multiply(ECOperations.java:269) ~[sunec.jar:1.8.0_302]
	at sun.security.ec.ECKeyPairGenerator.generateKeyPairImpl(ECKeyPairGenerator.java:199) ~[sunec.jar:1.8.0_302]
	at sun.security.ec.ECKeyPairGenerator.generateKeyPair(ECKeyPairGenerator.java:149) ~[sunec.jar:1.8.0_302]
	at java.security.KeyPairGenerator$Delegate.generateKeyPair(KeyPairGenerator.java:703) ~[na:1.8.0_302]
	at java.security.KeyPairGenerator.genKeyPair(KeyPairGenerator.java:470) ~[na:1.8.0_302]
	at com.jcraft.jsch.jce.KeyPairGenECDSA.init(KeyPairGenECDSA.java:55) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.jce.ECDHN.init(ECDHN.java:46) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.DHECN.init(DHECN.java:81) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.Session.checkKex(Session.java:2531) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.Session.checkKexes(Session.java:2508) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.Session.send_kexinit(Session.java:626) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.Session.connect(Session.java:307) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.Session.connect(Session.java:183) ~[jsch-0.1.53.jar:na]
	at clj_ssh.ssh$fn__2480.invokeStatic(ssh.clj:118) ~[jepsen-0.1.18.jar:na]
	at clj_ssh.ssh$fn__2480.invoke(ssh.clj:115) ~[jepsen-0.1.18.jar:na]
	at clj_ssh.ssh.protocols$fn__2438$G__2405__2447.invoke(protocols.clj:4) ~[jepsen-0.1.18.jar:na]
	at clj_ssh.ssh$connect.invokeStatic(ssh.clj:401) ~[jepsen-0.1.18.jar:na]
	at clj_ssh.ssh$connect.invoke(ssh.clj:397) ~[jepsen-0.1.18.jar:na]
	at jepsen.control$clj_ssh_session.invokeStatic(control.clj:331) ~[jepsen-0.1.18.jar:na]
	at jepsen.control$clj_ssh_session.invoke(control.clj:317) ~[jepsen-0.1.18.jar:na]
	at jepsen.control.SSHRemote$fn__3007.invoke(control.clj:340) ~[jepsen-0.1.18.jar:na]
	at jepsen.control.SSHRemote.connect(control.clj:339) ~[jepsen-0.1.18.jar:na]
	at jepsen.control$session$fn__3022.invoke(control.clj:370) ~[jepsen-0.1.18.jar:na]
	at jepsen.reconnect$open_BANG_$fn__2784.invoke(reconnect.clj:59) ~[jepsen-0.1.18.jar:na]
	at jepsen.reconnect$open_BANG_.invokeStatic(reconnect.clj:57) ~[jepsen-0.1.18.jar:na]
	at jepsen.reconnect$open_BANG_.invoke(reconnect.clj:54) ~[jepsen-0.1.18.jar:na]
	at jepsen.control$session.invokeStatic(control.clj:369) ~[jepsen-0.1.18.jar:na]
	at jepsen.control$session.invoke(control.clj:365) ~[jepsen-0.1.18.jar:na]
	at jepsen.redis.db$logged_crashes$fn__6648$fn__6649.invoke(db.clj:623) ~[classes/:na]
```