### PR TITLE
Add "protected-mode no" config to redis

### DIFF
--- a/src/jepsen/redis/db.clj
+++ b/src/jepsen/redis/db.clj
@@ -424,6 +424,7 @@
              :chdir   dir}
             binary
             ; config-file
+            :--protected-mode         "no"
             :--bind                   "0.0.0.0"
             :--dbfilename             db-file
             :--loadmodule             (str dir "/redisraft.so")

--- a/src/jepsen/redis/db.clj
+++ b/src/jepsen/redis/db.clj
@@ -40,7 +40,7 @@
 (defn install-build-tools!
   "Installs prerequisite packages for building redis and redisraft."
   []
-  (debian/install [:build-essential :cmake :libbsd-dev :libtool :autoconf :automake]))
+  (debian/install [:build-essential :cmake :libtool :autoconf :automake]))
 
 (defn checkout-repo!
   "Checks out a repo at the given version into a directory in build/ named
@@ -95,8 +95,6 @@
       (let [dir (checkout-repo! (:raft-repo test) "redis-raft" version)]
         (info "Building redis-raft" (:raft-version test))
         (c/cd dir
-          (c/exec :git :submodule :init)
-          (c/exec :git :submodule :update)
           ;(c/exec :make :clean)
           (c/exec :make :cleanall)
           (c/exec :make))


### PR DESCRIPTION
- Cleaned up unused bsd-lib dependency and submodule parts
- Added "protected-mode no" config to Redis which is necessary for latest Redis 